### PR TITLE
Adjust editor fields for post_box

### DIFF
--- a/data/editor.config
+++ b/data/editor.config
@@ -360,8 +360,7 @@
         <include group="poi_internet" />
       </type>
       <type id="amenity-post_box">
-        <include field="name" />
-        <include field="postcode" />
+        <include field="operator" />
       </type>
       <type id="amenity-post_office">
         <include group="poi_internet" />


### PR DESCRIPTION
Adjusted the editor fields for post_box. Removed name and address and added operator.

- name was removed because post_boxes almost never (only 1.85%) have a name and the OM name is most of the time populated with ref=* which causes problems when uploading to OSM
- address was removed because address tags are almost never used on post_boxes and some consider it as being wrong tagging (https://www.openstreetmap.org/changeset/163497850)

| Now | Before |
|--------|--------|
| <img width="300" src="https://github.com/user-attachments/assets/5a5b2a47-b17f-4f40-83e0-dd186f773883"/> | <img width="300" src="https://github.com/user-attachments/assets/316fe71e-b0f2-48c3-a89c-c94fb6262ecb"/> | 